### PR TITLE
Added fallback fonts

### DIFF
--- a/assets/template.svg
+++ b/assets/template.svg
@@ -10,7 +10,7 @@
 </g>
 <g id="info">
 <text x="50%" font-family="Verdana,DejaVu Sans,sans-serif" font-size="19" fill="white" y="148" text-anchor="middle">{{username}}</text>
-<text x="50%" font-family="Verdana,DejaVu Sans,sans-serif" font-size="12" fill="white" y="165" text-anchor="middle">{{name}}</text>
+<text x="50%" font-family="sans-serif" font-size="12" fill="white" y="165" text-anchor="middle">{{name}}</text>
 </g>
 <circle id="image_stroke" cx="75" cy="62" r="50.75" stroke="#30363D" stroke-width="1.5"/>
 <defs>

--- a/assets/template.svg
+++ b/assets/template.svg
@@ -8,9 +8,9 @@
 <rect id="image" x="25" y="12" width="100" height="100" fill="url(#pattern0)"/>
 </g>
 </g>
-<g xmlns="http://www.w3.org/2000/svg" id="info">
-<text x="50%" font-family="Verdana" font-size="19" fill="white" y="148" text-anchor="middle">{{username}}</text>
-<text xmlns="http://www.w3.org/2000/svg" x="50%" font-family="sans-serif" font-size="12" fill="white" y="165" text-anchor="middle">{{name}}</text>
+<g id="info">
+<text x="50%" font-family="Verdana,DejaVu Sans,sans-serif" font-size="19" fill="white" y="148" text-anchor="middle">{{username}}</text>
+<text x="50%" font-family="Verdana,DejaVu Sans,sans-serif" font-size="12" fill="white" y="165" text-anchor="middle">{{name}}</text>
 </g>
 <circle id="image_stroke" cx="75" cy="62" r="50.75" stroke="#30363D" stroke-width="1.5"/>
 <defs>


### PR DESCRIPTION
## Summary of Changes and Rationale

### Added Fallback Fonts

You probably remember from the discussion on your post on DEV that when DEV.to generates a png when this tool is used as an embed there, that the fonts are incorrect. Although Verdana that you are using is an excellent choice due to wide availability, it isn't available on all systems. In particular, it isn't available on Linux. I'm guessing that DEV probably does the conversion on Linux. Without any fallback font specified, it ends up using whatever the default system font is. And in the case of the DEV site, looks like the default is a serif font, when Verdana is a sans serif font.

I changed the `font-family` to provide a couple of fall-backs. Specifically, changed it to: `font-family="Verdana,DejaVu Sans,sans-serif"`. The reason for this combination is that DejaVu Sans is available on most Linux systems, and looks very similar to Verdana. It is meant to be an open source equivalent to Verdana. One additional nice thing about using it as a fall-back is that it is metrically compatible with Verdana. So any given string will have the same length in Verdana as it does with DejaVu Sans. So the combination of Verdana and DejaVu Sans should cover most systems. Verdana is widely available on Windows, and I think also on Mac (not sure of that though), and DejaVu Sans is available on most Linux systems. 

And then I put sans-serif in there at the end to cover the cases where neither of the first two are available. This way, if someone's web browser is forced to fall-back to whatever the default system font is, it will at least be a sans-serif, rather than a serif font.

### Removed Unnecessary Attribute

The `xmlns="http://www.w3.org/2000/svg"` attribute is only needed on the outermost `<svg>` element. There were a couple unnecessary instances of it as attributes on `<text>` and `<g>` tags. They're mostly harmless, but not needed anywhere other than the outermost `<svg>`. It would just be ignored on those other tags.
